### PR TITLE
Docs: Change FAQ and docker-compose.example.yml to set correct permissions for php user

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker volume rm asp_db-volume
 Solution: Grant `php`'s `www-data` user write permission for `config.php`.
 
 ```sh
-chown 33:33 ./config/ASP/config.php
+chown 82:82 ./config/ASP/config.php
 chmod 666 ./config/ASP/config.php
 docker-compose restart php
 ```

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,15 +16,15 @@ services:
           set -eu
 
           echo "Granting php's 'www-data' user write permissions"
-          chown -R 33:33 /src/ASP/system/backups
+          chown -R 82:82 /src/ASP/system/backups
           find /src/ASP/system/backups -type d -exec chmod 750 {} \;
           find /src/ASP/system/backups -type f -exec chmod 640 {} \;
 
-          chown -R 33:33 /src/ASP/system/cache
+          chown -R 82:82 /src/ASP/system/cache
           find /src/ASP/system/cache -type d -exec chmod 750 {} \;
           find /src/ASP/system/cache -type f -exec chmod 640 {} \;
 
-          chown -R 33:33 /src/ASP/system/logs
+          chown -R 82:82 /src/ASP/system/logs
           find /src/ASP/system/logs -type d -exec chmod 750 {} \;
           find /src/ASP/system/logs -type f -exec chmod 640 {} \;
 
@@ -32,7 +32,7 @@ services:
           mkdir -p /src/ASP/system/snapshots/processed
           mkdir -p /src/ASP/system/snapshots/unauthorized
           mkdir -p /src/ASP/system/snapshots/unprocessed
-          chown -R 33:33 /src/ASP/system/snapshots
+          chown -R 82:82 /src/ASP/system/snapshots
           find /src/ASP/system/snapshots -type d -exec chmod 750 {} \;
           find /src/ASP/system/snapshots -type f -exec chmod 640 {} \;
 


### PR DESCRIPTION
The `php` image was  changed to `alpine` base in #13. The `www-data` user in `alpine` is `82`, in contrast to `debian`'s which is `33`.