### PR TITLE
Enhancement: Bind `nginx` and `phpmyadmin` to ports `8081` and `8082`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Notes:
 ```sh
 # Start
 docker-compose up --build
-# Dashboard now available at http://localhost/ASP, username: admin, password admin. See ./config/ASP/config.php config file
-# phpmyadmin available at http://localhost:8080. Username: root, password: ascent. See ./config/ASP/config.php config file
+# Dashboard now available at http://localhost:8081/ASP, username: admin, password admin. See ./config/ASP/config.php config file
+# phpmyadmin available at http://localhost:8082. Username: root, password: ascent. See ./config/ASP/config.php config file
 
 # If xdebug is not working, iptables INPUT chain may be set to DROP on the docker bridge.
 # Execute this to allow php to reach the host machine via the docker0 bridge

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro # Customize as needed
     ports:
-      - 80:80
+      - 8081:80
     networks:
       - bf2-network
     depends_on:
@@ -92,7 +92,7 @@ services:
       # - PMA_ABSOLUTE_URI=https://phpmyadmin.example.com # Enable this if behind a reverse proxy
       - PMA_HOST=db
     ports:
-      - 8080:80
+      - 8082:80
     networks:
       - bf2-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - ./src:/src
       - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - 80:80
+      - 8081:80
     networks:
       - bf2-network
     depends_on:
@@ -100,7 +100,7 @@ services:
     environment:
       - PMA_HOST=db
     ports:
-      - 8080:80
+      - 8082:80
     networks:
       - bf2-network
 


### PR DESCRIPTION
Using these port numbers so that it is less likely to clash with system ports like `80` and to widely used `8080`.