### PR TITLE
Docs: Enhance full bf2 stack example documentation (Part 1)

### DIFF
--- a/docs/full-bf2-stack-example/config/bf2/mods/bf2/ai/aidefaultstrategies-custom-esai.ai
+++ b/docs/full-bf2-stack-example/config/bf2/mods/bf2/ai/aidefaultstrategies-custom-esai.ai
@@ -1,12 +1,12 @@
-rem ESAI Strategy : medium FCA PF
+rem esai strategy : medium fca pf
 
-rem -= load Enhanced SAI core =-
-run /mods/bf2/ESAI/Core/esaicore.ai
+rem -= load enhanced sai core =-
+run /mods/bf2/esai/core/esaicore.ai
 
-rem -= load Enhanced SAI default plugins =-
-run /mods/bf2/ESAI/Plugin/default/grabNeutrals.ai
-run /mods/bf2/ESAI/Plugin/default/endGame.ai
+rem -= load enhanced sai default plugins =-
+run /mods/bf2/esai/plugin/default/grabneutrals.ai
+run /mods/bf2/esai/plugin/default/endgame.ai
 
 rem -= load user plugins =-
-run /mods/bf2/ESAI/Plugin/user/userConditions.ai
-run /mods/bf2/ESAI/Plugin/user/focusedCounterAttack.ai
+run /mods/bf2/esai/plugin/user/userconditions.ai
+run /mods/bf2/esai/plugin/user/focusedcounterattack.ai

--- a/docs/full-bf2-stack-example/config/bf2/mods/bf2/ai/aidefaultstrategiesadd-custom-esai.ai
+++ b/docs/full-bf2-stack-example/config/bf2/mods/bf2/ai/aidefaultstrategiesadd-custom-esai.ai
@@ -1,0 +1,2 @@
+rem -= load strategy =-
+run /mods/bf2/esai/strategy/user/mediumfcapf.ai

--- a/docs/full-bf2-stack-example/config/bf2/mods/bf2/settings/maplist-custom-coop.con
+++ b/docs/full-bf2-stack-example/config/bf2/mods/bf2/settings/maplist-custom-coop.con
@@ -17,8 +17,8 @@ maplist.append taraba_quarry gpm_coop 16
 maplist.append zatar_wetlands gpm_coop 16
 
 ; mods/xpack coop
-ghost_town gpm_coop/16
-mass_destruction gpm_coop/16
-night_flight gpm_coop/16
-surge gpm_coop/16
-warlord gpm_coop/16
+maplist.append ghost_town gpm_coop 16
+maplist.append mass_destruction gpm_coop 16
+maplist.append night_flight gpm_coop 16
+maplist.append surge gpm_coop 16
+maplist.append warlord gpm_coop 16

--- a/docs/full-bf2-stack-example/config/bf2/mods/bf2/settings/maplist-custom-cq.con
+++ b/docs/full-bf2-stack-example/config/bf2/mods/bf2/settings/maplist-custom-cq.con
@@ -59,24 +59,24 @@ maplist.append zatar_wetlands gpm_cq 32
 maplist.append zatar_wetlands gpm_cq 64
 
 ; mods/xpack cq
-ghost_town gpm_cq/16
-ghost_town gpm_cq/32
-ghost_town gpm_cq/64
-iron_gator gpm_cq/16
-iron_gator gpm_cq/32
-iron_gator gpm_cq/64
-leviathan gpm_cq/16
-leviathan gpm_cq/32
-leviathan gpm_cq/64
-mass_destruction gpm_cq/16
-mass_destruction gpm_cq/32
-mass_destruction gpm_cq/64
-night_flight gpm_cq/16
-night_flight gpm_cq/32
-night_flight gpm_cq/64
-surge gpm_cq/16
-surge gpm_cq/32
-surge gpm_cq/64
-warlord gpm_cq/16
-warlord gpm_cq/32
-warlord gpm_cq/64
+maplist.append ghost_town gpm_cq 16
+maplist.append ghost_town gpm_cq 32
+maplist.append ghost_town gpm_cq 64
+maplist.append iron_gator gpm_cq 16
+maplist.append iron_gator gpm_cq 32
+maplist.append iron_gator gpm_cq 64
+maplist.append leviathan gpm_cq 16
+maplist.append leviathan gpm_cq 32
+maplist.append leviathan gpm_cq 64
+maplist.append mass_destruction gpm_cq 16
+maplist.append mass_destruction gpm_cq 32
+maplist.append mass_destruction gpm_cq 64
+maplist.append night_flight gpm_cq 16
+maplist.append night_flight gpm_cq 32
+maplist.append night_flight gpm_cq 64
+maplist.append surge gpm_cq 16
+maplist.append surge gpm_cq 32
+maplist.append surge gpm_cq 64
+maplist.append warlord gpm_cq 16
+maplist.append warlord gpm_cq 32
+maplist.append warlord gpm_cq 64

--- a/docs/full-bf2-stack-example/config/bf2sclone/nginx/nginx.conf
+++ b/docs/full-bf2-stack-example/config/bf2sclone/nginx/nginx.conf
@@ -60,6 +60,22 @@ http {
         }
         location ~ \.(gif|png|jpe?g|bmp|css|js|swf|wav|avi|mpg|ttf|woff|ico)$ {
             add_header Cache-Control "public, s-maxage=600, maxage=600";
+
+            # Show empty flag
+            location ~ (/game-images/armies)/.*\.(png|jpeg|jpg|gif)$ {
+                add_header Cache-Control "public, s-maxage=600, maxage=600";
+                try_files $uri $1/404.png =404;
+            }
+            # Show empty flag
+            location ~ (/game-images/flags)/.*\.(png|jpeg|jpg|gif)$ {
+                add_header Cache-Control "public, s-maxage=600, maxage=600";
+                try_files $uri $1/xx.png =404;
+            }
+            # Show empty flag
+            location ~ (/game-images/maps)/.*\.(png|jpeg|jpg|gif)$ {
+                add_header Cache-Control "public, s-maxage=600, maxage=600";
+                try_files $uri $1/map_NA.jpg =404;
+            }
             try_files $uri =404;
         }
 
@@ -85,7 +101,7 @@ http {
             fastcgi_buffering off;
 
             # Set fastcgi max execution response time
-            fastcgi_read_timeout 300s;
+            fastcgi_read_timeout 5s;
             fastcgi_split_path_info ^(.+\.php)(/.+)$;
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

--- a/docs/full-bf2-stack-example/docker-compose.yml
+++ b/docs/full-bf2-stack-example/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     volumes:
       - ./config/bf2/mods/bf2/ai/aidefault-custom.ai:/server/bf2/mods/bf2/ai/aidefault.ai:ro # Customize bots
       - ./config/bf2/mods/bf2/ai/aibehaviours-fixlookatwrapper.ai:/server/bf2/mods/bf2/ai/aibehaviours.ai:ro # LoopAtWrapper fix
-      # - ./config/bf2/mods/bf2/ai/aidefaultstrategies-custom.ai:/server/bf2/mods/bf2/ai/aidefaultstrategies.ai:ro # Enable ESAI with a default strategy for all maps
-      # - ./config/bf2/mods/bf2/ai/aidefaultstrategies-custom.ai.add:/server/bf2/mods/bf2/ai/aidefaultstrategies.ai.add:ro # Enable ESAI with a default strategy for all maps
+      # - ./config/bf2/mods/bf2/ai/aidefaultstrategies-custom-esai.ai:/server/bf2/mods/bf2/ai/aidefaultstrategies.ai:ro # Enable ESAI with a default strategy for all maps
+      # - ./config/bf2/mods/bf2/ai/aidefaultstrategiesadd-custom-esai.ai:/server/bf2/mods/bf2/ai/aidefaultstrategiesadd.ai:ro # Enable ESAI with a default strategy for all maps
       - ./config/bf2/mods/bf2/settings/serversettings-custom.con:/server/bf2/mods/bf2/settings/serversettings.con:ro # Server config
       - ./config/bf2/mods/bf2/settings/maplist-custom-coop.con:/server/bf2/mods/bf2/settings/maplist.con:ro # Maplist
       - ./config/bf2/python/bf2/BF2StatisticsConfig-custom.py:/server/bf2/python/bf2/BF2StatisticsConfig.py:ro # bf2stats python config
@@ -27,14 +27,14 @@ services:
   # The gamespy server
   prmasterserver:
     image: startersclan/prmasterserver:v0.1.0
+    volumes:
+      - prmasterserver-volume:/data
     ports:
       - 29900:29900/tcp # Login server
       - 29901:29901/tcp # Login server
       - 28910:28910/tcp # Master server
       - 27900:27900/udp # Master server
       - 29910:29910/udp # CD key server
-    volumes:
-      - prmasterserver-volume:/data
     networks:
       # Spoof all gamespy DNS for the gameserver connected to this network
       gamespy-network:
@@ -71,7 +71,7 @@ services:
   coredns:
     image: coredns/coredns:1.9.3
     ports:
-      - 53:53/udp
+      - 192.168.1.132:53:53/udp
     volumes:
       - ./config/coredns/Corefile:/Corefile:ro
       - ./config/coredns/hosts:/hosts:ro
@@ -163,21 +163,21 @@ services:
     image: startersclan/asp:3.1.0-nginx
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=traefik-network"
+      - "traefik.docker.network=${COMPOSE_PROJECT_NAME?err}_traefik-network"
       # traefik v2
       # http
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-gamespy-http.entrypoints=web"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-gamespy-http.rule=Host(`bf2web.gamespy.com`)" # Note: bf2web.gamespy.com doesn't need https
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-gamespy-http.entrypoints=web"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-gamespy-http.rule=Host(`bf2web.gamespy.com`)" # Note: bf2web.gamespy.com doesn't need https
       # http
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-nginx-http.entrypoints=web"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-nginx-http.rule=Host(`asp.example.com`)"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-nginx-http.middlewares=${COMPOSE_PROJECT_NAME}-asp-nginx-http-myRedirectScheme" # Redirect http to https
-      - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-asp-nginx-http-myRedirectScheme.redirectScheme.scheme=https" # Redirect http to https
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-nginx-http.entrypoints=web"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-nginx-http.rule=Host(`asp.example.com`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-nginx-http.middlewares=${COMPOSE_PROJECT_NAME?err}-asp-nginx-http-myRedirectScheme" # Redirect http to https
+      - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME?err}-asp-nginx-http-myRedirectScheme.redirectScheme.scheme=https" # Redirect http to https
       # https
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-nginx.entrypoints=websecure"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-nginx.tls"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-asp-nginx.rule=Host(`asp.example.com`)"
-      - "traefik.http.services.${COMPOSE_PROJECT_NAME}-asp-nginx.loadbalancer.server.port=80"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-nginx.entrypoints=websecure"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-nginx.tls"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-asp-nginx.rule=Host(`asp.example.com`)"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME?err}-asp-nginx.loadbalancer.server.port=80"
     # volumes:
     #   - ./config/ASP/nginx/nginx.conf:/etc/nginx/nginx.conf:ro # Customize only if needed
     networks:
@@ -212,18 +212,18 @@ services:
     image: startersclan/bf2stats:2.3.0-bf2sclone-nginx
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=traefik-network"
+      - "traefik.docker.network=${COMPOSE_PROJECT_NAME?err}_traefik-network"
       # traefik v2
       # http
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx-http.entrypoints=web"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx-http.rule=Host(`bf2sclone.example.com`)"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx-http.middlewares=${COMPOSE_PROJECT_NAME}-bf2sclone-nginx-http-myRedirectScheme" # Redirect http to https
-      - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx-http-myRedirectScheme.redirectScheme.scheme=https" # Redirect http to https
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx-http.entrypoints=web"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx-http.rule=Host(`bf2sclone.example.com`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx-http.middlewares=${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx-http-myRedirectScheme" # Redirect http to https
+      - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx-http-myRedirectScheme.redirectScheme.scheme=https" # Redirect http to https
       # https
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx.entrypoints=websecure"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx.tls"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx.rule=Host(`bf2sclone.example.com`)"
-      - "traefik.http.services.${COMPOSE_PROJECT_NAME}-bf2sclone-nginx.loadbalancer.server.port=80"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx.entrypoints=websecure"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx.tls"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx.rule=Host(`bf2sclone.example.com`)"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME?err}-bf2sclone-nginx.loadbalancer.server.port=80"
     # volumes:
     #   - ./config/bf2sclone/nginx/nginx.conf:/etc/nginx/nginx.conf:ro  # Customize only if needed
     networks:
@@ -269,18 +269,18 @@ services:
     image: phpmyadmin:5.2
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=traefik-network"
+      - "traefik.docker.network=${COMPOSE_PROJECT_NAME?err}_traefik-network"
       # traefik v2
       # http
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-phpmyadmin-http.entrypoints=web"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-phpmyadmin-http.rule=Host(`phpmyadmin.example.com`)"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-phpmyadmin-http.middlewares=${COMPOSE_PROJECT_NAME}-phpmyadmin-http-myRedirectScheme" # Redirect http to https
-      - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME}-phpmyadmin-http-myRedirectScheme.redirectScheme.scheme=https" # Redirect http to https
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-phpmyadmin-http.entrypoints=web"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-phpmyadmin-http.rule=Host(`phpmyadmin.example.com`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-phpmyadmin-http.middlewares=${COMPOSE_PROJECT_NAME?err}-phpmyadmin-http-myRedirectScheme" # Redirect http to https
+      - "traefik.http.middlewares.${COMPOSE_PROJECT_NAME?err}-phpmyadmin-http-myRedirectScheme.redirectScheme.scheme=https" # Redirect http to https
       # https
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-phpmyadmin.entrypoints=websecure"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-phpmyadmin.tls"
-      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-phpmyadmin.rule=Host(`phpmyadmin.example.com`)"
-      - "traefik.http.services.${COMPOSE_PROJECT_NAME}-phpmyadmin.loadbalancer.server.port=80"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-phpmyadmin.entrypoints=websecure"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-phpmyadmin.tls"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME?err}-phpmyadmin.rule=Host(`phpmyadmin.example.com`)"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME?err}-phpmyadmin.loadbalancer.server.port=80"
     environment:
       - PMA_ABSOLUTE_URI=https://phpmyadmin.example.com # Enable this if behind a reverse proxy
       - PMA_HOST=db
@@ -291,12 +291,9 @@ services:
 
 networks:
   gamespy-network:
-    name: gamespy-network
   bf2-network:
-    name: bf2-network
   traefik-public-network:
   traefik-network:
-    name: traefik-network
     internal: true
 
 volumes:


### PR DESCRIPTION
- Docs: Add support for fallback army flag, country flag, and map image in `bf2sclone` `nginx.conf` in full bf2 stack example
- Docs: Fix syntax error in xpack maplist entries
- Docs: Fix full bf2 stack example `docker-compose.yml` esai config files' bind mounts
- Docs: Fix esai configs that should use lowercase paths for linux servers
- Docs: Add details about running BF2 server, PRMasterServer, and traefik on host networking in full bf2 stack example
- Docs: Add quirks section to full bf2 stack example
- Docs: Namespace docker networks and traefik configuration by `COMPOSE_PROJECT_NAME` in full bf2 stack example `docker-compose.yml`