### PR TITLE
Docs (readme): Rename repository from `startersclan/ASP` to `startersclan/asp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ASP
 
-[![github-actions](https://github.com/startersclan/ASP/workflows/ci-master-pr/badge.svg)](https://github.com/startersclan/ASP/actions)
-[![github-release](https://img.shields.io/github/v/release/startersclan/ASP?style=flat-square)](https://github.com/startersclan/ASP/releases/)
+[![github-actions](https://github.com/startersclan/asp/workflows/ci-master-pr/badge.svg)](https://github.com/startersclan/asp/actions)
+[![github-release](https://img.shields.io/github/v/release/startersclan/asp?style=flat-square)](https://github.com/startersclan/asp/releases/)
 [![docker-image-size](https://img.shields.io/docker/image-size/startersclan/asp/nginx)](https://hub.docker.com/r/startersclan/asp)
 
 The new BF2Statistics 3.0 ASP, currently in public Beta. The GameSpy server to match is over at https://github.com/BF2Statistics/BattleSpy


### PR DESCRIPTION
This is to keep the repository name in lowercase, in order for better standardization across platforms. E.g. Docker Hub image references have to be in lowercase.
