### PR TITLE
Fix: Spelling mistake and missing time zone

### DIFF
--- a/src/ASP/frontend/modules/config/Config.php
+++ b/src/ASP/frontend/modules/config/Config.php
@@ -41,8 +41,9 @@ class Config extends Controller
             'Africa' => DateTimeZone::AFRICA,
             'America' => DateTimeZone::AMERICA,
             'Antarctica' => DateTimeZone::ANTARCTICA,
-            'Aisa' => DateTimeZone::ASIA,
+            'Asia' => DateTimeZone::ASIA,
             'Atlantic' => DateTimeZone::ATLANTIC,
+            'Australia' => DateTimeZone::AUSTRALIA,
             'Europe' => DateTimeZone::EUROPE,
             'Indian' => DateTimeZone::INDIAN,
             'Pacific' => DateTimeZone::PACIFIC


### PR DESCRIPTION
- Aisa is spelled Asia
- I always thought Australia was a lie.