### PR TITLE
fix: Grant unlock point per badge instead of per badge level

### DIFF
--- a/src/ASP/aspx/getunlocksinfo.php
+++ b/src/ASP/aspx/getunlocksinfo.php
@@ -252,7 +252,9 @@ function getBonusUnlockCountByBadges($pid, $rank, $connection)
     // Count number of kit badges obtained
     $checkawds = implode(",", $kitbadges);
     $query = <<<SQL
-SELECT COUNT(`award_id`) AS `count` 
+-- Using DISTINCT here to ensure we never return more than 7 unlock points based on badges
+-- Without DISTINCT, we'd return up to 14 points ($level = 2 and player has all level 2 + 3 badges)
+SELECT COUNT(DISTINCT `award_id`) AS `count` 
 FROM `player_award` 
 WHERE `player_id` = $pid 
   AND (


### PR DESCRIPTION
To determine the number badge-based unlock points, the current implementation does a `COUNT` of badges `>= $level`, with `$level` being the configured badge level for any unlock points (usually `2` = veteran). However, if a player has both the level `2` and level `3` badge, they receive two unlock points, since both are counted.

This sets the maximum number of badge-based unlock points to 14 (7 badges * 2 points per level). Which is nonsense because it results in the number of overall obtainable points (14 badge + 7 rank = 21) being *higher* than the number of things to unlock (7 classes * 2 unlocks = 14). Meaning a player who has all weapons unlocked will receive an unlock prompt without anything to unlock.