### PR TITLE
feat: Allow snapshots to be sent to sendsnapshot.aspx

### DIFF
--- a/config/ASP/etc/nginx/nginx.conf
+++ b/config/ASP/etc/nginx/nginx.conf
@@ -92,6 +92,11 @@ http {
             return 401;
         }
 
+        # Pass sendsnapshot.aspx to bf2statistics.php
+        location ~ ^/ASP/sendsnapshot\.aspx$ {
+            rewrite /ASP/(.*)\.aspx /ASP/bf2statistics.php last;
+        }
+
         # Pass .aspx to php
         location ~ ^/ASP/.*\.aspx$ {
             rewrite /ASP/(.*)\.aspx /ASP/index.php?aspx=$1 last;

--- a/src/ASP/.htaccess
+++ b/src/ASP/.htaccess
@@ -23,6 +23,13 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
 
+    # Redirect sendsnapshot ASPX file call to the regular snapshot endpoint (bf2statistics.php)
+    RewriteRule ^.*/sendsnapshot\.aspx$ bf2statistics.php [L,NC]
+
+    # Don't redirect direct links to non-existent files or directories to the index.php
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+
     # Redirect all ASPX file calls to the index.php?aspx=ASPX_FILENAME
     RewriteRule ^(.*)\.aspx$ index.php?aspx=$1 [QSA,L]
 


### PR DESCRIPTION
This change will allow use of an ASP "compliant" snapshot endpoint which can be proxied to by [unlockproxy](https://github.com/cetteup/unlockproxy)/[playerpath](https://github.com/cetteup/playerpath). To make use of this change, server admins only need to modify their config here (change `/ASP/bf2statistics.php` to `/ASP/sendsnapshot.aspx`):

https://github.com/startersclan/asp/blob/df86f71f1927426244e4c2436ec4149b2b1f0c23/src/python/bf2/BF2StatisticsConfig.py#L30-L35